### PR TITLE
Use tracked lockfile for cargo hash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,9 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
 
-  cargoHash = "sha256-36mecfyq4RDP2KNR8uXObSan0VSCMikjhiLNEvlDlPY=";
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
 
   buildInputs = [
     pkgs.libiconv


### PR DESCRIPTION
This will mean that I don't have problems with dependabot PRs
