### PR TITLE
feat: improve error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-types-convert"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f280f434214856abace637b1f944d50ccca216814813acd195cdd7f206ce17f"
+dependencies = [
+ "aws-smithy-types",
+ "chrono",
+]
+
+[[package]]
 name = "aws-smithy-xml"
 version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +715,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-cloudformation",
  "aws-smithy-types",
+ "aws-smithy-types-convert",
  "backoff",
  "chrono",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ aws-sdk-cloudformation = "1.51.0"
 aws-smithy-types = "1.2.7"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 humantime = "2.1.0"
+aws-smithy-types-convert = { version = "0.60.8", features = ["convert-chrono"] }
 
 [dev-dependencies]
 env_logger = "0.11.5"

--- a/src/aws/aws_sdk.rs
+++ b/src/aws/aws_sdk.rs
@@ -1,246 +1,76 @@
-use super::{
-    AwsCloudFormationClient, DescribeStackEventsError, DescribeStackEventsInput,
-    DescribeStackEventsOutput, DescribeStackResourcesError, DescribeStackResourcesInput,
-    DescribeStackResourcesOutput, DescribeStacksError, DescribeStacksInput, DescribeStacksOutput,
-    Output, Stack, StackEvent, StackResource,
+use super::AwsCloudFormationClient;
+
+use aws_sdk_cloudformation::config::http::HttpResponse;
+use aws_sdk_cloudformation::error::SdkError;
+use aws_sdk_cloudformation::operation::describe_stack_events::{
+    DescribeStackEventsError, DescribeStackEventsInput, DescribeStackEventsOutput,
 };
-
-use aws_sdk_cloudformation::error::ProvideErrorMetadata;
+use aws_sdk_cloudformation::operation::describe_stack_resources::{
+    DescribeStackResourcesError, DescribeStackResourcesInput, DescribeStackResourcesOutput,
+};
+use aws_sdk_cloudformation::operation::describe_stacks::{
+    DescribeStacksError, DescribeStacksInput, DescribeStacksOutput,
+};
 use aws_sdk_cloudformation::Client;
-use aws_smithy_types::date_time::Format;
 
-macro_rules! send_request_with_retry {
-    ($name:literal, $builder:ident, $err:ident) => {
-        backoff::future::retry(backoff::ExponentialBackoff::default(), || async {
-            let name = $name;
-            // any errors that deserve a retry should be wrapped in a `backoff::Error::Temporary`
-            // type so that the retry behaviour kicks in. Other types of errors should be
-            // `backoff::Error::Permanent` to indicate that the failure should not be retried.
-            $builder.clone().send().await.map_err(|e| match e {
-                aws_sdk_cloudformation::error::SdkError::TimeoutError(_) => {
-                    tracing::trace!(%name, "timeout error, retrying");
-                    backoff::Error::transient($err::Timeout)
-                }
-                e => {
-                    match e.code() {
-                        Some(code) if code == "Throttling" => {
-                            tracing::trace!(%name, "throttling error, retrying");
-                            backoff::Error::transient($err::Throttling)
-                        },
-                        _ => backoff::Error::permanent($err::Unknown(e.to_string())),
+// macro_rules! send_request_with_retry {
+//     ($name:literal, $builder:ident, $err:ident) => {
+//         backoff::future::retry(backoff::ExponentialBackoff::default(), || async {
+//             let name = $name;
+//             // any errors that deserve a retry should be wrapped in a `backoff::Error::Temporary`
+//             // type so that the retry behaviour kicks in. Other types of errors should be
+//             // `backoff::Error::Permanent` to indicate that the failure should not be retried.
+//             $builder.clone().send().await.map_err(|e| match e {
+//                 aws_sdk_cloudformation::error::SdkError::TimeoutError(_) => {
+//                     tracing::trace!(%name, "timeout error, retrying");
+//                     backoff::Error::transient($err::Timeout)
+//                 }
+//                 e => {
+//                     match e.code() {
+//                         Some(code) if code == "Throttling" => {
+//                             tracing::trace!(%name, "throttling error, retrying");
+//                             backoff::Error::transient($err::Throttling)
+//                         },
+//                         _ => backoff::Error::permanent($err::Unknown(e.to_string())),
 
-                    }
-                }
-            })
-        })
-        .await
-        .map(From::from)
-        .map_err(From::from)
-    };
-}
+//                     }
+//                 }
+//             })
+//         })
+//         .await
+//         .map(From::from)
+//         .map_err(From::from)
+//     };
+// }
 
 #[async_trait::async_trait]
 impl AwsCloudFormationClient for Client {
     async fn describe_stacks(
         &self,
         input: DescribeStacksInput,
-    ) -> Result<DescribeStacksOutput, DescribeStacksError> {
+    ) -> Result<DescribeStacksOutput, SdkError<DescribeStacksError, HttpResponse>> {
         let builder = Client::describe_stacks(self).stack_name(input.stack_name.unwrap());
         let builder = builder.set_next_token(input.next_token);
-        send_request_with_retry!("describe_stacks", builder, DescribeStacksError)
+        // TODO: retries
+        builder.send().await
     }
 
     async fn describe_stack_events(
         &self,
         input: DescribeStackEventsInput,
-    ) -> Result<DescribeStackEventsOutput, DescribeStackEventsError> {
+    ) -> Result<DescribeStackEventsOutput, SdkError<DescribeStackEventsError, HttpResponse>> {
         let builder = Client::describe_stack_events(self).stack_name(input.stack_name.unwrap());
         let builder = builder.set_next_token(input.next_token);
-        send_request_with_retry!("describe_stack_events", builder, DescribeStackEventsError)
+        // TODO: retries
+        builder.send().await
     }
 
     async fn describe_stack_resources(
         &self,
         input: DescribeStackResourcesInput,
-    ) -> Result<DescribeStackResourcesOutput, DescribeStackResourcesError> {
-        let builder = Client::describe_stack_resources(self).stack_name(input.stack_name);
-        send_request_with_retry!(
-            "describe_stack_resources",
-            builder,
-            DescribeStackResourcesError
-        )
-    }
-}
-
-impl From<aws_sdk_cloudformation::operation::describe_stack_events::DescribeStackEventsOutput>
-    for DescribeStackEventsOutput
-{
-    fn from(
-        o: aws_sdk_cloudformation::operation::describe_stack_events::DescribeStackEventsOutput,
-    ) -> Self {
-        Self {
-            next_token: o.next_token,
-            stack_events: o
-                .stack_events
-                .unwrap_or_default()
-                .iter()
-                .map(From::from)
-                .collect(),
-        }
-    }
-}
-
-impl From<&aws_sdk_cloudformation::types::StackEvent> for StackEvent {
-    fn from(e: &aws_sdk_cloudformation::types::StackEvent) -> Self {
-        Self {
-            event_id: e.event_id.clone().unwrap(),
-            timestamp: e.timestamp.unwrap().fmt(Format::DateTime).unwrap(),
-            logical_resource_id: e.logical_resource_id.clone(),
-            resource_status: e.resource_status.as_ref().map(|s| s.as_str().to_owned()),
-            stack_name: e.stack_name.as_ref().unwrap().clone(),
-            resource_status_reason: e.resource_status_reason.clone(),
-            resource_type: e.resource_type.clone(),
-        }
-    }
-}
-
-impl From<aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksOutput>
-    for DescribeStacksOutput
-{
-    fn from(o: aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksOutput) -> Self {
-        Self {
-            stacks: o
-                .stacks
-                .unwrap_or_default()
-                .iter()
-                .map(From::from)
-                .collect(),
-        }
-    }
-}
-
-impl From<&aws_sdk_cloudformation::types::Stack> for Stack {
-    fn from(s: &aws_sdk_cloudformation::types::Stack) -> Self {
-        Self {
-            outputs: s
-                .outputs
-                .as_ref()
-                .map(|o| o.iter().map(From::from).collect()),
-        }
-    }
-}
-
-impl From<&aws_sdk_cloudformation::types::Output> for Output {
-    fn from(o: &aws_sdk_cloudformation::types::Output) -> Self {
-        Self {
-            key: o.output_key.as_ref().unwrap().to_string(),
-            value: o.output_value.as_ref().unwrap().to_string(),
-        }
-    }
-}
-
-impl From<aws_sdk_cloudformation::operation::describe_stack_resources::DescribeStackResourcesOutput>
-    for DescribeStackResourcesOutput
-{
-    fn from(
-        o: aws_sdk_cloudformation::operation::describe_stack_resources::DescribeStackResourcesOutput,
-    ) -> Self {
-        Self {
-            stack_resources: o
-                .stack_resources
-                .unwrap_or_default()
-                .iter()
-                .map(From::from)
-                .collect(),
-        }
-    }
-}
-
-impl From<&aws_sdk_cloudformation::types::StackResource> for StackResource {
-    fn from(r: &aws_sdk_cloudformation::types::StackResource) -> Self {
-        Self {
-            resource_type: r.resource_type.as_ref().unwrap().to_string(),
-            physical_resource_id: r.physical_resource_id.clone(),
-            stack_name: r.stack_name.as_ref().unwrap().to_string(),
-        }
-    }
-}
-
-impl
-    From<
-        aws_sdk_cloudformation::error::SdkError<
-            aws_sdk_cloudformation::operation::describe_stack_events::DescribeStackEventsError,
-        >,
-    > for DescribeStackEventsError
-{
-    fn from(
-        e: aws_sdk_cloudformation::error::SdkError<
-            aws_sdk_cloudformation::operation::describe_stack_events::DescribeStackEventsError,
-        >,
-    ) -> Self {
-        match e {
-            aws_sdk_cloudformation::error::SdkError::ConstructionFailure(_) => {
-                DescribeStackEventsError::Unknown("construction failure".to_string())
-            }
-            aws_sdk_cloudformation::error::SdkError::TimeoutError(_) => {
-                DescribeStackEventsError::Timeout
-            }
-            aws_sdk_cloudformation::error::SdkError::DispatchFailure(_) => {
-                DescribeStackEventsError::Dispatch
-            }
-            aws_sdk_cloudformation::error::SdkError::ResponseError { .. } => {
-                DescribeStackEventsError::Response
-            }
-            aws_sdk_cloudformation::error::SdkError::ServiceError { .. } => {
-                DescribeStackEventsError::Service
-            }
-            _ => todo!(),
-        }
-    }
-}
-
-impl
-    From<
-        aws_sdk_cloudformation::error::SdkError<
-            aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksError,
-        >,
-    > for DescribeStacksError
-{
-    fn from(
-        e: aws_sdk_cloudformation::error::SdkError<
-            aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksError,
-        >,
-    ) -> Self {
-        match e {
-            aws_sdk_cloudformation::error::SdkError::ConstructionFailure(_) => todo!(),
-            aws_sdk_cloudformation::error::SdkError::TimeoutError(_) => todo!(),
-            aws_sdk_cloudformation::error::SdkError::DispatchFailure(_) => todo!(),
-            aws_sdk_cloudformation::error::SdkError::ResponseError { .. } => todo!(),
-            aws_sdk_cloudformation::error::SdkError::ServiceError { .. } => todo!(),
-            _ => todo!(),
-        }
-    }
-}
-
-impl
-    From<
-        aws_sdk_cloudformation::error::SdkError<
-            aws_sdk_cloudformation::operation::describe_stack_resources::DescribeStackResourcesError,
-        >,
-    > for DescribeStackResourcesError
-{
-    fn from(
-        e: aws_sdk_cloudformation::error::SdkError<
-            aws_sdk_cloudformation::operation::describe_stack_resources::DescribeStackResourcesError,
-        >,
-    ) -> Self {
-        match e {
-            aws_sdk_cloudformation::error::SdkError::ConstructionFailure(_) => todo!(),
-            aws_sdk_cloudformation::error::SdkError::TimeoutError(_) => todo!(),
-            aws_sdk_cloudformation::error::SdkError::DispatchFailure(_) => todo!(),
-            aws_sdk_cloudformation::error::SdkError::ResponseError { .. } => todo!(),
-            aws_sdk_cloudformation::error::SdkError::ServiceError { .. } => todo!(),
-            _ => todo!(),
-        }
+    ) -> Result<DescribeStackResourcesOutput, SdkError<DescribeStackResourcesError, HttpResponse>>
+    {
+        let builder = Client::describe_stack_resources(self).stack_name(input.stack_name.unwrap());
+        builder.send().await
     }
 }

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -1,3 +1,17 @@
+use aws_sdk_cloudformation::{
+    config::http::HttpResponse,
+    error::SdkError,
+    operation::{
+        describe_stack_events::{
+            DescribeStackEventsError, DescribeStackEventsInput, DescribeStackEventsOutput,
+        },
+        describe_stack_resources::{
+            DescribeStackResourcesError, DescribeStackResourcesInput, DescribeStackResourcesOutput,
+        },
+        describe_stacks::{DescribeStacksError, DescribeStacksInput, DescribeStacksOutput},
+    },
+};
+
 mod aws_sdk;
 
 /// Trait representing interactions with CloudFormation
@@ -6,113 +20,15 @@ pub(crate) trait AwsCloudFormationClient {
     async fn describe_stacks(
         &self,
         input: DescribeStacksInput,
-    ) -> Result<DescribeStacksOutput, DescribeStacksError>;
+    ) -> Result<DescribeStacksOutput, SdkError<DescribeStacksError, HttpResponse>>;
 
     async fn describe_stack_events(
         &self,
         input: DescribeStackEventsInput,
-    ) -> Result<DescribeStackEventsOutput, DescribeStackEventsError>;
+    ) -> Result<DescribeStackEventsOutput, SdkError<DescribeStackEventsError, HttpResponse>>;
 
     async fn describe_stack_resources(
         &self,
         input: DescribeStackResourcesInput,
-    ) -> Result<DescribeStackResourcesOutput, DescribeStackResourcesError>;
-}
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum DescribeStacksError {
-    #[error("request timeout")]
-    Timeout,
-    #[error("request was throttled")]
-    Throttling,
-    #[error("unknown error: {0}")]
-    Unknown(String),
-}
-
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub(crate) enum DescribeStackEventsError {
-    #[error("request timeout")]
-    Timeout,
-    #[error("request was throttled")]
-    Throttling,
-    #[error("unknown error: {0}")]
-    Unknown(String),
-    #[error("error dispatching request")]
-    Dispatch,
-    #[error("error with respone")]
-    Response,
-    #[error("service error")]
-    Service,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum DescribeStackResourcesError {
-    #[error("request timeout")]
-    Timeout,
-    #[error("request was throttled")]
-    Throttling,
-    #[error("unknown error: {0}")]
-    Unknown(String),
-}
-
-// DescribeStacks
-
-#[derive(Default)]
-pub(crate) struct DescribeStacksInput {
-    pub(crate) stack_name: Option<String>,
-    pub(crate) next_token: Option<String>,
-}
-
-pub(crate) struct Output {
-    pub(crate) key: String,
-    pub(crate) value: String,
-}
-
-pub(crate) struct Stack {
-    pub(crate) outputs: Option<Vec<Output>>,
-}
-
-pub(crate) struct DescribeStacksOutput {
-    pub(crate) stacks: Vec<Stack>,
-}
-
-// DescribeStackEvents
-
-#[derive(Debug, Default)]
-pub(crate) struct DescribeStackEventsInput {
-    pub(crate) stack_name: Option<String>,
-    pub(crate) next_token: Option<String>,
-}
-
-pub(crate) struct DescribeStackEventsOutput {
-    pub(crate) next_token: Option<String>,
-    pub(crate) stack_events: Vec<StackEvent>,
-}
-
-pub(crate) struct StackEvent {
-    pub(crate) event_id: String,
-    pub(crate) timestamp: String,
-    pub(crate) logical_resource_id: Option<String>,
-    pub(crate) resource_status: Option<String>,
-    pub(crate) resource_type: Option<String>,
-    pub(crate) stack_name: String,
-    pub(crate) resource_status_reason: Option<String>,
-}
-
-// DescribeStackResources
-
-#[derive(Debug, Default)]
-pub(crate) struct DescribeStackResourcesInput {
-    pub(crate) stack_name: String,
-}
-
-pub(crate) struct DescribeStackResourcesOutput {
-    pub(crate) stack_resources: Vec<StackResource>,
-}
-
-pub(crate) struct StackResource {
-    pub(crate) resource_type: String,
-    pub(crate) physical_resource_id: Option<String>,
-    pub(crate) stack_name: String,
+    ) -> Result<DescribeStackResourcesOutput, SdkError<DescribeStackResourcesError, HttpResponse>>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,10 @@
+use aws_sdk_cloudformation::error::SdkError;
 use eyre::WrapErr;
 use serde::Deserialize;
 use std::str::FromStr;
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum Error {
+pub(crate) enum Error<E> {
     #[error("error parsing --since argument")]
     ParseSince,
     #[error("no credentials found")]
@@ -18,8 +19,8 @@ pub(crate) enum Error {
     ErrorResponse(ErrorResponse),
     #[error("other error {0}")]
     Other(String),
-    #[error("aws client error")]
-    Client,
+    #[error("aws client error: {0:?}")]
+    Client(SdkError<E>),
 }
 
 #[derive(Debug, PartialEq, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn parse_since_argument(src: &str) -> Result<DateTime<Utc>> {
             .ok_or(eyre::eyre!("invalid time"));
     }
 
-    Err(Error::ParseSince).wrap_err("error parsing since argument")
+    Err(Error::<()>::ParseSince).wrap_err("error parsing since argument")
 }
 
 /// Tail CloudFormation deployments
@@ -120,7 +120,7 @@ async fn create_client(endpoint_url: &Option<String>) -> aws_sdk_cloudformation:
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> eyre::Result<()> {
     tracing_subscriber::fmt::init();
     color_eyre::install().unwrap();
 
@@ -160,7 +160,7 @@ async fn main() {
         tracing::info!("prefetching tasks");
         match tail.prefetch().await {
             Ok(_) => {}
-            Err(e) => match e.downcast_ref::<Error>() {
+            Err(e) => match e.downcast_ref::<Error<()>>() {
                 Some(Error::NoCredentials) => {
                     eprintln!("Error: no valid credentials found");
                     std::process::exit(1);
@@ -193,9 +193,9 @@ async fn main() {
             Ok(_) => {
                 tracing::info!("exiting from tail successfully");
                 // found our exit early condition
-                return;
+                return Ok(());
             }
-            Err(e) => match e.downcast_ref::<Error>() {
+            Err(e) => match e.downcast_ref::<Error<()>>() {
                 Some(Error::CredentialsExpired) => {
                     eprintln!("Error: your credentials have expired");
                     std::process::exit(1);

--- a/src/stack_status.rs
+++ b/src/stack_status.rs
@@ -31,7 +31,7 @@ pub(crate) enum StackStatus {
 }
 
 impl TryFrom<&str> for StackStatus {
-    type Error = Error;
+    type Error = Error<()>;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         use StackStatus::*;


### PR DESCRIPTION
# Motivation

While using `cftail` when an error occurred, the message was terse and cryptic. This is not very useful.

# Changes

* Use AWS SDK types directly since we are an application, not libary and the extra step to maintaining an extra error type is just overhead
* Wrap errors with `eyre` properly so that the error trace is available
